### PR TITLE
Use same prefix used in the models

### DIFF
--- a/admin_ip_whitelist/middleware.py
+++ b/admin_ip_whitelist/middleware.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.http import HttpResponseForbidden
 from django.core.exceptions import MiddlewareNotUsed
 from django.core.cache import cache
-from models import DjangoAdminAccessIPWhitelist
+from models import DjangoAdminAccessIPWhitelist, ADMIN_ACCESS_WHITELIST_PREFIX
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class AdminAcceessIPWhiteListMiddleware(object):
 
         # Prefix All keys in cache to avoid key collisions
         self.ABUSE_PREFIX = 'DJANGO_ADMIN_ACCESS_WHITELIST_ABUSE:'
-        self.WHITELIST_PREFIX = 'DJANGO_ADMIN_ACCESS_WHITELIST_WHITELIST:'
+        self.WHITELIST_PREFIX = ADMIN_ACCESS_WHITELIST_PREFIX
 
         for whitelist in DjangoAdminAccessIPWhitelist.objects.all():
             cache_key = self.WHITELIST_PREFIX + whitelist.ip


### PR DESCRIPTION
Proposed repair to a bug prevents the deletion and addition of new IP address at runtime, since the cache is not deleted or checked properly (in the middleware).

It seems like there is a mistake that the prefix 'cache_key' that is used at the models.py have to be the same as the one used in the middleware.py.

This proposed change just import the same whitelist 'cache_key' prefix used in the models.py to the middleware.
